### PR TITLE
dpif-netdev: Fix updating netdev_flow->stats.used field

### DIFF
--- a/lib/dpif-netdev.c
+++ b/lib/dpif-netdev.c
@@ -3593,8 +3593,6 @@ dp_netdev_offload_used(struct dp_netdev_flow *netdev_flow,
     if (ret) {
             return -1;
     }
-    atomic_store_relaxed(&netdev_flow->stats.used,
-                    pmd->ctx.now / 1000);
     non_atomic_ullong_add(&netdev_flow->stats.packet_count, stats.n_packets);
     non_atomic_ullong_add(&netdev_flow->stats.byte_count, stats.n_bytes);
 


### PR DESCRIPTION
When calling dp_netdev_offload_used() function - only 'n_packets' and
'n_bytes' fields should be updated. The 'used' field should remain
intact since it is updated exclusively by calling function
packet_batch_per_flow_execute().
Otherwise in case there is no traffic while 'used' fields is
continuously incremented by the other function - the flow will not be
aged out. In case there is no traffic the correct flow aging can be
verified by running the command:
watch ovs-appctl dpif/dump-flows <bridge name>
The output should demonstrate that the flow has been deleted after the
configured aging time.

Signed-off-by: Ophir Munk <ophirmu@mellanox.com>