### PR TITLE
ofproto-dpif: Add offloaded:yes to dpif/dump-flow

### DIFF
--- a/ofproto/ofproto-dpif.c
+++ b/ofproto/ofproto-dpif.c
@@ -5731,6 +5731,9 @@ ofproto_unixctl_dpif_dump_flows(struct unixctl_conn *conn,
         dpif_flow_stats_format(&f.stats, &ds);
         ds_put_cstr(&ds, ", actions:");
         format_odp_actions(&ds, f.actions, f.actions_len, portno_names);
+        if (f.attrs.offloaded) {
+            ds_put_cstr(&ds, ", offloaded:yes");
+        }
         ds_put_char(&ds, '\n');
     }
     dpif_flow_dump_thread_destroy(flow_dump_thread);


### PR DESCRIPTION
When executing command: ovs-appctl dpif/dump-flows <bridge name> and
in case a flow is offloaded - add an "offloaded:yes" indication.

Signed-off-by: Ophir Munk <ophirmu@mellanox.com>