### PR TITLE
netdev-rte-offloads: Extract pattern matching handling to a function.

### DIFF
--- a/lib/dpif-netdev.c
+++ b/lib/dpif-netdev.c
@@ -2096,7 +2096,7 @@ dp_netdev_pmd_find_dpcls(struct dp_netdev_pmd_thread *pmd,
     return cls;
 }
 
-#define MAX_FLOW_MARK       (UINT32_MAX - 1)
+#define MAX_AMOUNT_FLOW_MARK (UINT32_MAX - 1 - OFFLOAD_RESERVED_MARK)
 #define INVALID_FLOW_MARK   (UINT32_MAX)
 
 struct megaflow_to_mark_data {
@@ -2123,7 +2123,8 @@ flow_mark_alloc(void)
 
     if (!flow_mark.pool) {
         /* Haven't initiated yet, do it here */
-        flow_mark.pool = id_pool_create(OFFLOAD_RESERVED_MARK, MAX_FLOW_MARK);
+        flow_mark.pool = id_pool_create(OFFLOAD_RESERVED_MARK,
+                                        MAX_AMOUNT_FLOW_MARK);
     }
 
     if (id_pool_alloc_id(flow_mark.pool, &mark)) {

--- a/lib/netdev-rte-offloads.c
+++ b/lib/netdev-rte-offloads.c
@@ -367,18 +367,18 @@ struct action_rss_data {
 
 static struct action_rss_data *
 add_flow_rss_action(struct flow_actions *actions,
-                    struct netdev *netdev) {
+                    uint16_t num_queues) {
     int i;
     struct action_rss_data *rss_data;
 
     rss_data = xmalloc(sizeof(struct action_rss_data) +
-                       sizeof(uint16_t) * netdev->n_rxq);
+                       sizeof(uint16_t) * num_queues);
     *rss_data = (struct action_rss_data) {
         .conf = (struct rte_flow_action_rss) {
             .func = RTE_ETH_HASH_FUNCTION_DEFAULT,
             .level = 0,
             .types = 0,
-            .queue_num = netdev->n_rxq,
+            .queue_num = num_queues,
             .queue = rss_data->queue,
             .key_len = 0,
             .key  = NULL
@@ -386,7 +386,7 @@ add_flow_rss_action(struct flow_actions *actions,
     };
 
     /* Override queue array with default */
-    for (i = 0; i < netdev->n_rxq; i++) {
+    for (i = 0; i < num_queues; i++) {
        rss_data->queue[i] = i;
     }
 
@@ -575,7 +575,7 @@ netdev_dpdk_add_rte_flow_offload(struct netdev *netdev,
     add_flow_action(&actions, RTE_FLOW_ACTION_TYPE_MARK, &mark);
 
 
-    rss = add_flow_rss_action(&actions, netdev);
+    rss = add_flow_rss_action(&actions, netdev->n_rxq);
     add_flow_action(&actions, RTE_FLOW_ACTION_TYPE_END, NULL);
 
     flow = netdev_dpdk_rte_flow_create(netdev, &flow_attr,patterns.items,

--- a/lib/netdev-rte-offloads.c
+++ b/lib/netdev-rte-offloads.c
@@ -138,6 +138,24 @@ struct flow_actions {
 };
 
 static void
+free_flow_patterns(struct flow_patterns *patterns) {
+    if (patterns && patterns->items) {
+        free(patterns->items);
+        patterns->items = NULL;
+        patterns->cnt = 0;
+    }
+}
+
+static void
+free_flow_actions(struct flow_actions *actions) {
+    if (actions && actions->actions) {
+        free(actions->actions);
+        actions->actions = NULL;
+        actions->cnt = 0;
+    }
+}
+
+static void
 dump_flow_pattern(struct rte_flow_item *item)
 {
     struct ds s;
@@ -674,8 +692,8 @@ netdev_rte_offload_add_default_flow(struct netdev_rte_port *rte_port) {
             " : message : %s\n", netdev_get_name(rte_port->netdev), error.type,
             error.message);
 
-        free(def_patterns.items);
-        free(def_actions.actions);
+        free_flow_patterns(&def_patterns);
+        free_flow_actions(&def_actions);
 
         result = netdev_dpdk_rte_flow_destroy(rte_port->netdev, def_flow,
                                               &error);
@@ -777,8 +795,9 @@ netdev_dpdk_add_rte_flow_offload(struct netdev *netdev,
     }
 
 out:
-    free(patterns.items);
-    free(actions.actions);
+    free_flow_patterns(&patterns);
+    free_flow_actions(&actions);
+
     return flow;
 }
 
@@ -1454,7 +1473,7 @@ netdev_rte_offload_decap(struct netdev_rte_port *rte_port,
                            patterns->items, actions.actions, &error);
 
     free(rss);
-    free(actions.actions);
+    free_flow_actions(&actions);
     if (!flow) {
         VLOG_ERR("rte flow create offload error: %u : message : %s\n",
                  error.type, error.message);
@@ -1554,7 +1573,7 @@ netdev_vport_vxlan_add_rte_flow_offload(struct netdev_rte_port *rte_port,
    }
 
 out:
-    free(patterns.items);
+    free_flow_patterns(&patterns);
     return ret;
 }
 

--- a/lib/netdev-rte-offloads.c
+++ b/lib/netdev-rte-offloads.c
@@ -91,6 +91,18 @@ struct ufid_to_odp {
 
 static struct cmap ufid_to_portid_map = CMAP_INITIALIZER;
 
+struct flow_items {
+    struct rte_flow_item_eth  eth;
+    struct rte_flow_item_vlan vlan;
+    struct rte_flow_item_ipv4 ipv4;
+    union {
+        struct rte_flow_item_tcp  tcp;
+        struct rte_flow_item_udp  udp;
+        struct rte_flow_item_sctp sctp;
+        struct rte_flow_item_icmp icmp;
+    };
+};
+
 //------------
 
 /*
@@ -449,6 +461,149 @@ add_flow_rss_action(struct flow_actions *actions,
 }
 
 static int
+add_flow_patterns(struct flow_patterns *patterns,
+                  struct flow_items *spec,
+                  struct flow_items *mask,
+                  const struct match *match) {
+    /* Eth */
+    if (!eth_addr_is_zero(match->wc.masks.dl_src) ||
+        !eth_addr_is_zero(match->wc.masks.dl_dst)) {
+        memcpy(&spec->eth.dst, &match->flow.dl_dst, sizeof spec->eth.dst);
+        memcpy(&spec->eth.src, &match->flow.dl_src, sizeof spec->eth.src);
+        spec->eth.type = match->flow.dl_type;
+
+        memcpy(&mask->eth.dst, &match->wc.masks.dl_dst, sizeof mask->eth.dst);
+        memcpy(&mask->eth.src, &match->wc.masks.dl_src, sizeof mask->eth.src);
+        mask->eth.type = match->wc.masks.dl_type;
+
+        add_flow_pattern(patterns, RTE_FLOW_ITEM_TYPE_ETH,
+                         &spec->eth, &mask->eth);
+    } else {
+        /*
+         * If user specifies a flow (like UDP flow) without L2 patterns,
+         * OVS will at least set the dl_type. Normally, it's enough to
+         * create an eth pattern just with it. Unluckily, some Intel's
+         * NIC (such as XL710) doesn't support that. Below is a workaround,
+         * which simply matches any L2 pkts.
+         */
+        add_flow_pattern(patterns, RTE_FLOW_ITEM_TYPE_ETH, NULL, NULL);
+    }
+
+    /* VLAN */
+    if (match->wc.masks.vlans[0].tci && match->flow.vlans[0].tci) {
+        spec->vlan.tci  = match->flow.vlans[0].tci & ~htons(VLAN_CFI);
+        mask->vlan.tci  = match->wc.masks.vlans[0].tci & ~htons(VLAN_CFI);
+
+        /* match any protocols */
+        mask->vlan.inner_type = 0;
+
+        add_flow_pattern(patterns, RTE_FLOW_ITEM_TYPE_VLAN,
+                         &spec->vlan, &mask->vlan);
+    }
+
+    /* IP v4 */
+    uint8_t proto = 0;
+    if (match->flow.dl_type == htons(ETH_TYPE_IP)) {
+        spec->ipv4.hdr.type_of_service = match->flow.nw_tos;
+        spec->ipv4.hdr.time_to_live    = match->flow.nw_ttl;
+        spec->ipv4.hdr.next_proto_id   = match->flow.nw_proto;
+        spec->ipv4.hdr.src_addr        = match->flow.nw_src;
+        spec->ipv4.hdr.dst_addr        = match->flow.nw_dst;
+
+        mask->ipv4.hdr.type_of_service = match->wc.masks.nw_tos;
+        mask->ipv4.hdr.time_to_live    = match->wc.masks.nw_ttl;
+        mask->ipv4.hdr.next_proto_id   = match->wc.masks.nw_proto;
+        mask->ipv4.hdr.src_addr        = match->wc.masks.nw_src;
+        mask->ipv4.hdr.dst_addr        = match->wc.masks.nw_dst;
+
+        add_flow_pattern(patterns, RTE_FLOW_ITEM_TYPE_IPV4,
+                         &spec->ipv4, &mask->ipv4);
+
+        /* Save proto for L4 protocol setup */
+        proto = spec->ipv4.hdr.next_proto_id &
+                mask->ipv4.hdr.next_proto_id;
+    }
+
+    if (proto != IPPROTO_ICMP && proto != IPPROTO_UDP  &&
+        proto != IPPROTO_SCTP && proto != IPPROTO_TCP  &&
+        (match->wc.masks.tp_src ||
+         match->wc.masks.tp_dst ||
+         match->wc.masks.tcp_flags)) {
+        VLOG_DBG("L4 Protocol (%u) not supported", proto);
+        return -1;
+    }
+
+    if ((match->wc.masks.tp_src && match->wc.masks.tp_src != OVS_BE16_MAX) ||
+        (match->wc.masks.tp_dst && match->wc.masks.tp_dst != OVS_BE16_MAX)) {
+        return -1;
+    }
+
+    switch (proto) {
+    case IPPROTO_TCP:
+        spec->tcp.hdr.src_port  = match->flow.tp_src;
+        spec->tcp.hdr.dst_port  = match->flow.tp_dst;
+        spec->tcp.hdr.data_off  = ntohs(match->flow.tcp_flags) >> 8;
+        spec->tcp.hdr.tcp_flags = ntohs(match->flow.tcp_flags) & 0xff;
+
+        mask->tcp.hdr.src_port  = match->wc.masks.tp_src;
+        mask->tcp.hdr.dst_port  = match->wc.masks.tp_dst;
+        mask->tcp.hdr.data_off  = ntohs(match->wc.masks.tcp_flags) >> 8;
+        mask->tcp.hdr.tcp_flags = ntohs(match->wc.masks.tcp_flags) & 0xff;
+
+        add_flow_pattern(patterns, RTE_FLOW_ITEM_TYPE_TCP,
+                         &spec->tcp, &mask->tcp);
+
+        /* proto == TCP and ITEM_TYPE_TCP, thus no need for proto match */
+        mask->ipv4.hdr.next_proto_id = 0;
+        break;
+
+    case IPPROTO_UDP:
+        spec->udp.hdr.src_port = match->flow.tp_src;
+        spec->udp.hdr.dst_port = match->flow.tp_dst;
+
+        mask->udp.hdr.src_port = match->wc.masks.tp_src;
+        mask->udp.hdr.dst_port = match->wc.masks.tp_dst;
+
+        add_flow_pattern(patterns, RTE_FLOW_ITEM_TYPE_UDP,
+                         &spec->udp, &mask->udp);
+
+        /* proto == UDP and ITEM_TYPE_UDP, thus no need for proto match */
+        mask->ipv4.hdr.next_proto_id = 0;
+        break;
+
+    case IPPROTO_SCTP:
+        spec->sctp.hdr.src_port = match->flow.tp_src;
+        spec->sctp.hdr.dst_port = match->flow.tp_dst;
+
+        mask->sctp.hdr.src_port = match->wc.masks.tp_src;
+        mask->sctp.hdr.dst_port = match->wc.masks.tp_dst;
+
+        add_flow_pattern(patterns, RTE_FLOW_ITEM_TYPE_SCTP,
+                         &spec->sctp, &mask->sctp);
+
+        /* proto == SCTP and ITEM_TYPE_SCTP, thus no need for proto match */
+        mask->ipv4.hdr.next_proto_id = 0;
+        break;
+
+    case IPPROTO_ICMP:
+        spec->icmp.hdr.icmp_type = (uint8_t) ntohs(match->flow.tp_src);
+        spec->icmp.hdr.icmp_code = (uint8_t) ntohs(match->flow.tp_dst);
+
+        mask->icmp.hdr.icmp_type = (uint8_t) ntohs(match->wc.masks.tp_src);
+        mask->icmp.hdr.icmp_code = (uint8_t) ntohs(match->wc.masks.tp_dst);
+
+        add_flow_pattern(patterns, RTE_FLOW_ITEM_TYPE_ICMP,
+                         &spec->icmp, &mask->icmp);
+
+        /* proto == ICMP and ITEM_TYPE_ICMP, thus no need for proto match */
+        mask->ipv4.hdr.next_proto_id = 0;
+        break;
+    }
+
+    return 0;
+}
+
+static int
 netdev_dpdk_add_rte_flow_offload(struct netdev *netdev,
                                  const struct match *match,
                                  struct nlattr *nl_actions OVS_UNUSED,
@@ -465,157 +620,15 @@ netdev_dpdk_add_rte_flow_offload(struct netdev *netdev,
     struct flow_actions actions = { .actions = NULL, .cnt = 0 };
     struct rte_flow *flow;
     struct rte_flow_error error;
-    uint8_t proto = 0;
     int ret = 0;
-    struct flow_items {
-        struct rte_flow_item_eth  eth;
-        struct rte_flow_item_vlan vlan;
-        struct rte_flow_item_ipv4 ipv4;
-        union {
-            struct rte_flow_item_tcp  tcp;
-            struct rte_flow_item_udp  udp;
-            struct rte_flow_item_sctp sctp;
-            struct rte_flow_item_icmp icmp;
-        };
-    } spec, mask;
+    struct flow_items spec, mask;
 
     memset(&spec, 0, sizeof spec);
     memset(&mask, 0, sizeof mask);
 
-    /* Eth */
-    if (!eth_addr_is_zero(match->wc.masks.dl_src) ||
-        !eth_addr_is_zero(match->wc.masks.dl_dst)) {
-        memcpy(&spec.eth.dst, &match->flow.dl_dst, sizeof spec.eth.dst);
-        memcpy(&spec.eth.src, &match->flow.dl_src, sizeof spec.eth.src);
-        spec.eth.type = match->flow.dl_type;
-
-        memcpy(&mask.eth.dst, &match->wc.masks.dl_dst, sizeof mask.eth.dst);
-        memcpy(&mask.eth.src, &match->wc.masks.dl_src, sizeof mask.eth.src);
-        mask.eth.type = match->wc.masks.dl_type;
-
-        add_flow_pattern(&patterns, RTE_FLOW_ITEM_TYPE_ETH,
-                         &spec.eth, &mask.eth);
-    } else {
-        /*
-         * If user specifies a flow (like UDP flow) without L2 patterns,
-         * OVS will at least set the dl_type. Normally, it's enough to
-         * create an eth pattern just with it. Unluckily, some Intel's
-         * NIC (such as XL710) doesn't support that. Below is a workaround,
-         * which simply matches any L2 pkts.
-         */
-        add_flow_pattern(&patterns, RTE_FLOW_ITEM_TYPE_ETH, NULL, NULL);
-    }
-
-    /* VLAN */
-    if (match->wc.masks.vlans[0].tci && match->flow.vlans[0].tci) {
-        spec.vlan.tci  = match->flow.vlans[0].tci & ~htons(VLAN_CFI);
-        mask.vlan.tci  = match->wc.masks.vlans[0].tci & ~htons(VLAN_CFI);
-
-        /* match any protocols */
-        mask.vlan.inner_type = 0;
-
-        add_flow_pattern(&patterns, RTE_FLOW_ITEM_TYPE_VLAN,
-                         &spec.vlan, &mask.vlan);
-    }
-
-    /* IP v4 */
-    if (match->flow.dl_type == htons(ETH_TYPE_IP)) {
-        spec.ipv4.hdr.type_of_service = match->flow.nw_tos;
-        spec.ipv4.hdr.time_to_live    = match->flow.nw_ttl;
-        spec.ipv4.hdr.next_proto_id   = match->flow.nw_proto;
-        spec.ipv4.hdr.src_addr        = match->flow.nw_src;
-        spec.ipv4.hdr.dst_addr        = match->flow.nw_dst;
-
-        mask.ipv4.hdr.type_of_service = match->wc.masks.nw_tos;
-        mask.ipv4.hdr.time_to_live    = match->wc.masks.nw_ttl;
-        mask.ipv4.hdr.next_proto_id   = match->wc.masks.nw_proto;
-        mask.ipv4.hdr.src_addr        = match->wc.masks.nw_src;
-        mask.ipv4.hdr.dst_addr        = match->wc.masks.nw_dst;
-
-        add_flow_pattern(&patterns, RTE_FLOW_ITEM_TYPE_IPV4,
-                         &spec.ipv4, &mask.ipv4);
-
-        /* Save proto for L4 protocol setup */
-        proto = spec.ipv4.hdr.next_proto_id &
-                mask.ipv4.hdr.next_proto_id;
-    }
-
-    if (proto != IPPROTO_ICMP && proto != IPPROTO_UDP  &&
-        proto != IPPROTO_SCTP && proto != IPPROTO_TCP  &&
-        (match->wc.masks.tp_src ||
-         match->wc.masks.tp_dst ||
-         match->wc.masks.tcp_flags)) {
-        VLOG_DBG("L4 Protocol (%u) not supported", proto);
-        ret = -1;
+    ret = add_flow_patterns(&patterns, &spec, &mask, match);
+    if (ret) {
         goto out;
-    }
-
-    if ((match->wc.masks.tp_src && match->wc.masks.tp_src != OVS_BE16_MAX) ||
-        (match->wc.masks.tp_dst && match->wc.masks.tp_dst != OVS_BE16_MAX)) {
-        ret = -1;
-        goto out;
-    }
-
-    switch (proto) {
-    case IPPROTO_TCP:
-        spec.tcp.hdr.src_port  = match->flow.tp_src;
-        spec.tcp.hdr.dst_port  = match->flow.tp_dst;
-        spec.tcp.hdr.data_off  = ntohs(match->flow.tcp_flags) >> 8;
-        spec.tcp.hdr.tcp_flags = ntohs(match->flow.tcp_flags) & 0xff;
-
-        mask.tcp.hdr.src_port  = match->wc.masks.tp_src;
-        mask.tcp.hdr.dst_port  = match->wc.masks.tp_dst;
-        mask.tcp.hdr.data_off  = ntohs(match->wc.masks.tcp_flags) >> 8;
-        mask.tcp.hdr.tcp_flags = ntohs(match->wc.masks.tcp_flags) & 0xff;
-
-        add_flow_pattern(&patterns, RTE_FLOW_ITEM_TYPE_TCP,
-                         &spec.tcp, &mask.tcp);
-
-        /* proto == TCP and ITEM_TYPE_TCP, thus no need for proto match */
-        mask.ipv4.hdr.next_proto_id = 0;
-        break;
-
-    case IPPROTO_UDP:
-        spec.udp.hdr.src_port = match->flow.tp_src;
-        spec.udp.hdr.dst_port = match->flow.tp_dst;
-
-        mask.udp.hdr.src_port = match->wc.masks.tp_src;
-        mask.udp.hdr.dst_port = match->wc.masks.tp_dst;
-
-        add_flow_pattern(&patterns, RTE_FLOW_ITEM_TYPE_UDP,
-                         &spec.udp, &mask.udp);
-
-        /* proto == UDP and ITEM_TYPE_UDP, thus no need for proto match */
-        mask.ipv4.hdr.next_proto_id = 0;
-        break;
-
-    case IPPROTO_SCTP:
-        spec.sctp.hdr.src_port = match->flow.tp_src;
-        spec.sctp.hdr.dst_port = match->flow.tp_dst;
-
-        mask.sctp.hdr.src_port = match->wc.masks.tp_src;
-        mask.sctp.hdr.dst_port = match->wc.masks.tp_dst;
-
-        add_flow_pattern(&patterns, RTE_FLOW_ITEM_TYPE_SCTP,
-                         &spec.sctp, &mask.sctp);
-
-        /* proto == SCTP and ITEM_TYPE_SCTP, thus no need for proto match */
-        mask.ipv4.hdr.next_proto_id = 0;
-        break;
-
-    case IPPROTO_ICMP:
-        spec.icmp.hdr.icmp_type = (uint8_t) ntohs(match->flow.tp_src);
-        spec.icmp.hdr.icmp_code = (uint8_t) ntohs(match->flow.tp_dst);
-
-        mask.icmp.hdr.icmp_type = (uint8_t) ntohs(match->wc.masks.tp_src);
-        mask.icmp.hdr.icmp_code = (uint8_t) ntohs(match->wc.masks.tp_dst);
-
-        add_flow_pattern(&patterns, RTE_FLOW_ITEM_TYPE_ICMP,
-                         &spec.icmp, &mask.icmp);
-
-        /* proto == ICMP and ITEM_TYPE_ICMP, thus no need for proto match */
-        mask.ipv4.hdr.next_proto_id = 0;
-        break;
     }
 
     add_flow_pattern(&patterns, RTE_FLOW_ITEM_TYPE_END, NULL, NULL);

--- a/lib/netdev.h
+++ b/lib/netdev.h
@@ -204,10 +204,11 @@ struct offload_info {
     uint8_t tunnel_csum_on; /* Tunnel header with checksum */
 
     /*
-     * The flow mark id assigened to the flow. If any pkts hit the flow,
+     * The flow mark id assigned to the flow. If any pkts hit the flow,
      * it will be in the pkt meta data.
      */
     uint32_t flow_mark;
+    bool is_hwol; /* true if flow is fully offloaded */
 };
 struct dpif_class;
 struct netdev_flow_dump;


### PR DESCRIPTION
Handling of flows pattern matching is being done as part of
netdev_dpdk_add_rte_flow_offload function.

Extracting this logic to a dedicate function provides better
readability and an option to reuse that logic in a different
place.

Signed-off-by: Asaf Penso <asafp@mellanox.com>