### PR TITLE
dpif: Add marked packets stats

### DIFF
--- a/lib/dpctl.c
+++ b/lib/dpctl.c
@@ -826,9 +826,9 @@ format_dpif_flow(struct ds *ds, const struct dpif_flow *f, struct hmap *ports,
                     dpctl_p->verbosity);
     ds_put_cstr(ds, ", ");
 
-    dpif_flow_stats_format(&f->stats, ds);
+    dpif_flow_stats_format(&f->stats, ds, false);
     if (dpctl_p->verbosity && f->attrs.offloaded) {
-        ds_put_cstr(ds, ", offloaded:yes");
+        ds_put_cstr(ds, ", offloaded:yes\n");
     }
     if (dpctl_p->verbosity && f->attrs.dp_layer) {
         ds_put_format(ds, ", dp:%s", f->attrs.dp_layer);
@@ -1089,7 +1089,7 @@ dpctl_put_flow(int argc, const char *argv[], enum dpif_flow_put_flags flags,
         struct ds s;
 
         ds_init(&s);
-        dpif_flow_stats_format(&stats, &s);
+        dpif_flow_stats_format(&stats, &s, false);
         dpctl_print(dpctl_p, "%s\n", ds_cstr(&s));
         ds_destroy(&s);
     }
@@ -1237,7 +1237,7 @@ dpctl_del_flow(int argc, const char *argv[], struct dpctl_params *dpctl_p)
         struct ds s;
 
         ds_init(&s);
-        dpif_flow_stats_format(&stats, &s);
+        dpif_flow_stats_format(&stats, &s, false);
         dpctl_print(dpctl_p, "%s\n", ds_cstr(&s));
         ds_destroy(&s);
     }

--- a/lib/dpif.c
+++ b/lib/dpif.c
@@ -884,13 +884,19 @@ dpif_flow_stats_extract(const struct flow *flow, const struct dp_packet *packet,
     stats->tcp_flags = ntohs(flow->tcp_flags);
     stats->n_bytes = dp_packet_size(packet);
     stats->n_packets = 1;
+    stats->n_marked = 0;
     stats->used = used;
 }
 
 /* Appends a human-readable representation of 'stats' to 's'. */
 void
-dpif_flow_stats_format(const struct dpif_flow_stats *stats, struct ds *s)
+dpif_flow_stats_format(const struct dpif_flow_stats *stats, struct ds *s,
+                       bool verbose)
 {
+    if (verbose) {
+        ds_put_format(s, "marked:%"PRIu64", ", stats->n_marked);
+    }
+
     ds_put_format(s, "packets:%"PRIu64", bytes:%"PRIu64", used:",
                   stats->n_packets, stats->n_bytes);
     if (stats->used) {
@@ -1738,7 +1744,7 @@ log_flow_message(const struct dpif *dpif, int error,
     odp_flow_format(key, key_len, mask, mask_len, NULL, &ds, true);
     if (stats) {
         ds_put_cstr(&ds, ", ");
-        dpif_flow_stats_format(stats, &ds);
+        dpif_flow_stats_format(stats, &ds, true);
     }
     if (actions || actions_len) {
         ds_put_cstr(&ds, ", actions:");

--- a/lib/dpif.c
+++ b/lib/dpif.c
@@ -885,6 +885,7 @@ dpif_flow_stats_extract(const struct flow *flow, const struct dp_packet *packet,
     stats->n_bytes = dp_packet_size(packet);
     stats->n_packets = 1;
     stats->n_marked = 0;
+    stats->n_hwcnt = 0;	
     stats->used = used;
 }
 
@@ -895,6 +896,7 @@ dpif_flow_stats_format(const struct dpif_flow_stats *stats, struct ds *s,
 {
     if (verbose) {
         ds_put_format(s, "marked:%"PRIu64", ", stats->n_marked);
+        ds_put_format(s, "hw_cnt:%"PRIu64", ", stats->n_hwcnt);
     }
 
     ds_put_format(s, "packets:%"PRIu64", bytes:%"PRIu64", used:",

--- a/lib/dpif.h
+++ b/lib/dpif.h
@@ -492,6 +492,8 @@ struct dpif_flow_stats {
     uint64_t n_bytes;
     long long int used;
     uint16_t tcp_flags;
+    /* HW offload stats. */
+    uint64_t n_marked;
 };
 
 struct dpif_flow_attrs {
@@ -501,7 +503,8 @@ struct dpif_flow_attrs {
 
 void dpif_flow_stats_extract(const struct flow *, const struct dp_packet *packet,
                              long long int used, struct dpif_flow_stats *);
-void dpif_flow_stats_format(const struct dpif_flow_stats *, struct ds *);
+void dpif_flow_stats_format(const struct dpif_flow_stats *, struct ds *,
+                            bool verbose);
 
 enum dpif_flow_put_flags {
     DPIF_FP_CREATE = 1 << 0,    /* Allow creating a new flow. */

--- a/lib/dpif.h
+++ b/lib/dpif.h
@@ -492,8 +492,9 @@ struct dpif_flow_stats {
     uint64_t n_bytes;
     long long int used;
     uint16_t tcp_flags;
-    /* HW offload stats. */
-    uint64_t n_marked;
+    /* HW offload. */
+    uint64_t n_marked; /* Number of marked packets */
+    uint64_t n_hwcnt;  /* Number of HW counted packets. */
 };
 
 struct dpif_flow_attrs {

--- a/ofproto/ofproto-dpif.c
+++ b/ofproto/ofproto-dpif.c
@@ -4437,6 +4437,7 @@ rule_construct(struct rule *rule_)
     rule->stats.n_packets = 0;
     rule->stats.n_bytes = 0;
     rule->stats.used = rule->up.modified;
+    rule->stats.n_marked = 0;
     rule->recirc_id = 0;
     rule->new_rule = NULL;
     rule->forward_counts = false;
@@ -5728,7 +5729,7 @@ ofproto_unixctl_dpif_dump_flows(struct unixctl_conn *conn,
         odp_flow_format(f.key, f.key_len, f.mask, f.mask_len,
                         portno_names, &ds, verbosity);
         ds_put_cstr(&ds, ", ");
-        dpif_flow_stats_format(&f.stats, &ds);
+        dpif_flow_stats_format(&f.stats, &ds, verbosity);
         ds_put_cstr(&ds, ", actions:");
         format_odp_actions(&ds, f.actions, f.actions_len, portno_names);
         if (f.attrs.offloaded) {


### PR DESCRIPTION
When running datapath dump-flow command  with "-m" (more verbosity)
"ovs-appctl dpif/dump-flows -m <bridge-name>" add printing of the
number of marked packets.

Signed-off-by: Ophir Munk <ophirmu@mellanox.com>