### PR TITLE
Fix rogue output flow on br-phy

### DIFF
--- a/ofproto/ofproto-dpif-upcall.c
+++ b/ofproto/ofproto-dpif-upcall.c
@@ -425,7 +425,7 @@ udpif_create(struct dpif_backer *backer, struct dpif *dpif)
 
     udpif->dpif = dpif;
     udpif->backer = backer;
-    atomic_init(&udpif->flow_limit, MIN(ofproto_flow_limit, 10000));
+    atomic_init(&udpif->flow_limit, 1000000);
     udpif->reval_seq = seq_create();
     udpif->dump_seq = seq_create();
     latch_init(&udpif->exit_latch);
@@ -935,7 +935,7 @@ udpif_revalidator(void *arg)
                        && flow_limit < n_flows * 1000 / duration) {
                 flow_limit += 1000;
             }
-            flow_limit = MIN(ofproto_flow_limit, MAX(flow_limit, 1000));
+            flow_limit = 1000000;
             atomic_store_relaxed(&udpif->flow_limit, flow_limit);
 
             if (duration > 2000) {


### PR DESCRIPTION
This includes the two patches to resolve [Redmine#1717193](https://redmine.mellanox.com/issues/1717193), where the decapped VXLAN packets would be seen on `br-phy` and cause a *rogue* flow with `actions:br-phy` be created.

The first of the patches is a **workaround** and should be reverted as soon as the root cause is fixed.