### PR TITLE
Read hw stats for upstream on top hwol for baidu

### DIFF
--- a/lib/dpif-netdev.c
+++ b/lib/dpif-netdev.c
@@ -487,6 +487,9 @@ struct dp_netdev_flow_stats {
     atomic_ullong packet_count;    /* Number of packets matched. */
     atomic_ullong byte_count;      /* Number of bytes matched. */
     atomic_uint16_t tcp_flags;     /* Bitwise-OR of seen tcp_flags values. */
+    /* HW offload stats. */
+    atomic_ullong mark_count;      /* Number of marked packets matched. */
+    atomic_ullong hw_count;        /* Number of HW counted packets. */	
 };
 
 /* A flow in 'dp_netdev_pmd_thread's 'flow_table'.
@@ -3022,6 +3025,11 @@ get_dpif_flow_stats(const struct dp_netdev_flow *netdev_flow_,
     stats->used = used;
     atomic_read_relaxed(&netdev_flow->stats.tcp_flags, &flags);
     stats->tcp_flags = flags;
+    /* HW offload stats. */
+    atomic_read_relaxed(&netdev_flow->stats.mark_count, &n);
+    stats->n_marked = n;
+    atomic_read_relaxed(&netdev_flow->stats.hw_count, &n);
+    stats->n_hwcnt = n;
 }
 
 /* Converts to the dpif_flow format, using 'key_buf' and 'mask_buf' for
@@ -3628,6 +3636,7 @@ dp_netdev_offload_used(struct dp_netdev_flow *netdev_flow,
                     pmd->ctx.now / 1000);
     non_atomic_ullong_add(&netdev_flow->stats.packet_count, stats.n_packets);
     non_atomic_ullong_add(&netdev_flow->stats.byte_count, stats.n_bytes);
+    non_atomic_ullong_add(&netdev_flow->stats.hw_count, stats.n_packets);
 
     return 0;
 }
@@ -6795,12 +6804,12 @@ dp_netdev_input__(struct dp_netdev_pmd_thread *pmd,
 
     /* All the flow batches need to be reset before any call to
      * packet_batch_per_flow_execute() as it could potentially trigger
-     * recirculation. When a packet matching flow ‘j’ happens to be
+     * recirculation. When a packet matching flow ???j??? happens to be
      * recirculated, the nested call to dp_netdev_input__() could potentially
      * classify the packet as matching another flow - say 'k'. It could happen
      * that in the previous call to dp_netdev_input__() that same flow 'k' had
      * already its own batches[k] still waiting to be served.  So if its
-     * ‘batch’ member is not reset, the recirculated packet would be wrongly
+     * ???batch??? member is not reset, the recirculated packet would be wrongly
      * appended to batches[k] of the 1st call to dp_netdev_input__(). */
     for (i = 0; i < n_batches; i++) {
         batches[i].flow->batch = NULL;

--- a/lib/dpif-netdev.c
+++ b/lib/dpif-netdev.c
@@ -545,6 +545,7 @@ struct dp_netdev_flow {
 
     bool dead;
     uint32_t mark;               /* Unique flow mark assigned to a flow */
+    bool is_hwol;                /* true if flow is fully offloaded */
 
     /* Statistics. */
     struct dp_netdev_flow_stats stats;
@@ -2389,6 +2390,7 @@ dp_netdev_flow_offload_put(struct dp_flow_offload_item *offload)
         }
     }
     info.flow_mark = mark;
+    info.is_hwol = false;
 
     ovs_mutex_lock(&pmd->dp->port_mutex);
     port = dp_netdev_lookup_port(pmd->dp, in_port);
@@ -2401,6 +2403,7 @@ dp_netdev_flow_offload_put(struct dp_flow_offload_item *offload)
                           offload->actions_len, &flow->mega_ufid, &info,
                           NULL);
     ovs_mutex_unlock(&pmd->dp->port_mutex);
+    flow->is_hwol = info.is_hwol;
 
     if (ret) {
         if (!modification) {
@@ -3071,8 +3074,8 @@ dp_netdev_flow_to_dpif_flow(const struct dp_netdev_flow *netdev_flow,
     flow->pmd_id = netdev_flow->pmd_id;
     get_dpif_flow_stats(netdev_flow, &flow->stats);
 
-    flow->attrs.offloaded = false;
-    flow->attrs.dp_layer = "ovs";
+    flow->attrs.offloaded = netdev_flow->is_hwol;
+    flow->attrs.dp_layer = "ovs-dpdk";
 }
 
 static int
@@ -3242,6 +3245,7 @@ dp_netdev_flow_add(struct dp_netdev_pmd_thread *pmd,
     flow->dead = false;
     flow->batch = NULL;
     flow->mark = INVALID_FLOW_MARK;
+    flow->is_hwol = false;
     *CONST_CAST(unsigned *, &flow->pmd_id) = pmd->core_id;
     *CONST_CAST(struct flow *, &flow->flow) = match->flow;
     *CONST_CAST(ovs_u128 *, &flow->ufid) = *ufid;
@@ -3669,10 +3673,9 @@ dpif_netdev_flow_dump_next(struct dpif_flow_dump_thread *thread_,
                 flow = netdev_flows[n_flows] = CONTAINER_OF(node,
                                                     struct dp_netdev_flow,
                                                     node);
-                /* Read offload stats in case ufid equals mega_ufid. */
+                /* Read hardware stats in case of hardware offload */
                 if (netdev_is_flow_api_enabled() &&
-                   (!memcmp(&flow->ufid, &flow->mega_ufid,
-                            sizeof flow->ufid))) {
+                   (flow->is_hwol)) {
                     dp_netdev_offload_used(flow, pmd);
                 }
             }

--- a/lib/dpif.c
+++ b/lib/dpif.c
@@ -877,6 +877,8 @@ dpif_flow_stats_extract(const struct flow *flow, const struct dp_packet *packet,
     stats->tcp_flags = ntohs(flow->tcp_flags);
     stats->n_bytes = dp_packet_size(packet);
     stats->n_packets = 1;
+    stats->n_marked = 0;
+    stats->n_hwcnt = 0;	
     stats->used = used;
 }
 
@@ -884,6 +886,9 @@ dpif_flow_stats_extract(const struct flow *flow, const struct dp_packet *packet,
 void
 dpif_flow_stats_format(const struct dpif_flow_stats *stats, struct ds *s)
 {
+    ds_put_format(s, "marked:%"PRIu64", ", stats->n_marked);
+    ds_put_format(s, "hw_cnt:%"PRIu64", ", stats->n_hwcnt);
+
     ds_put_format(s, "packets:%"PRIu64", bytes:%"PRIu64", used:",
                   stats->n_packets, stats->n_bytes);
     if (stats->used) {

--- a/lib/dpif.h
+++ b/lib/dpif.h
@@ -492,6 +492,9 @@ struct dpif_flow_stats {
     uint64_t n_bytes;
     long long int used;
     uint16_t tcp_flags;
+    /* HW offload. */
+    uint64_t n_marked; /* Number of marked packets */
+    uint64_t n_hwcnt;  /* Number of HW counted packets. */
 };
 
 struct dpif_flow_attrs {

--- a/lib/netdev-dpdk.h
+++ b/lib/netdev-dpdk.h
@@ -18,8 +18,12 @@
 #define NETDEV_DPDK_H
 
 #include <config.h>
+#include <stdint.h>
 
 #include "openvswitch/compiler.h"
+
+/* DPDK library uses uint16_t for port_id. */
+typedef uint16_t dpdk_port_t;
 
 struct dp_packet;
 struct netdev;
@@ -47,6 +51,8 @@ netdev_dpdk_rte_flow_create(struct netdev *netdev,
 
 int netdev_dpdk_get_port_id(const struct netdev *netdev);
 bool netdev_dpdk_is_uplink_port(const struct netdev *netdev);
+
+dpdk_port_t netdev_dpdk_get_port(const struct netdev *netdev);
 
 #else
 

--- a/lib/netdev-provider.h
+++ b/lib/netdev-provider.h
@@ -881,6 +881,13 @@ struct netdev_class {
     int (*flow_del)(struct netdev *, const ovs_u128 *ufid,
                     struct dpif_flow_stats *);
 
+    /* Get offloaded flow stats. When a flow is fully offloaded, reading the
+     * PMD stats will result in no updates. In order to reflect the actual
+     * stats the hardware must be querried.
+     * Return 0 if successful, otherwise returns a positive errno value. */
+    int (*flow_stats_get)(struct netdev *netdev, const ovs_u128 *ufid,
+                          struct dpif_flow_stats *stats);
+
     /* Initializies the netdev flow api.
      * Return 0 if successful, otherwise returns a positive errno value. */
     int (*init_flow_api)(struct netdev *);

--- a/lib/netdev-rte-offloads.c
+++ b/lib/netdev-rte-offloads.c
@@ -1322,6 +1322,66 @@ netdev_rte_offloads_flow_put(struct netdev *netdev, struct match *match,
     return 0;
 }
 
+int
+netdev_dpdk_flow_stats_get(struct netdev *netdev OVS_UNUSED,
+                           const ovs_u128 *ufid,
+                           struct dpif_flow_stats *stats)
+{
+    int ret;
+    struct rte_flow_error error;
+    struct rte_flow_query_count query;
+
+    memset(stats, 0, sizeof *stats);
+
+    struct ufid_to_odp *uto = ufid_to_portid_get(ufid);
+    if (!uto) {
+        return EINVAL;
+    }
+    struct netdev_rte_port *rte_port = netdev_rte_port_search(uto->dp_port,
+                                                              &port_map);
+    if (!rte_port) {
+        return EINVAL;
+    }
+    struct ufid_hw_offload *uho = ufid_hw_offload_find(ufid,
+                                                       &rte_port->ufid_to_rte);
+    if (!uho) {
+        return EINVAL;
+    }
+
+    struct rte_flow_action action = {RTE_FLOW_ACTION_TYPE_COUNT, NULL};
+    memset(&query, 0, sizeof query);
+    /* reset counters after query */
+    query.reset = 1;
+
+    struct rte_flow *rte_flow;
+    struct netdev *netd;
+    dpdk_port_t dpdk_port_id;
+    /*
+     * Several HW flows may be related for one ufid. For example for one vport
+     * flow we may have created a HW flow per each physical port. Therefore we
+     * need to loop over all HW flows related to this ufid and accumulate the
+     * statitistics related to it.
+     */
+    for (int i = 0 ; i < uho->curr_idx ; i++) {
+        netd = uho->rte_flow_data[i].netdev;
+        rte_flow = uho->rte_flow_data[i].flow;
+        if (rte_flow) {
+            dpdk_port_id = netdev_dpdk_get_port(netd);
+            if (dpdk_port_id != DPDK_ETH_PORT_ID_INVALID) {
+                ret = rte_flow_query(dpdk_port_id, rte_flow,
+                                     &action, &query, &error);
+                if (ret) {
+                    return -ret;
+                }
+                stats->n_packets += (query.hits_set) ? query.hits : 0;
+                stats->n_bytes += (query.bytes_set) ? query.bytes : 0;
+            }
+        }
+    }
+
+    return 0;
+}
+
 static int
 netdev_offloads_flow_del(const ovs_u128 *ufid)
 {

--- a/lib/netdev-rte-offloads.h
+++ b/lib/netdev-rte-offloads.h
@@ -50,6 +50,8 @@ int netdev_rte_offloads_flow_put(struct netdev *netdev, struct match *match,
                                  struct dpif_flow_stats *stats);
 int netdev_rte_offloads_flow_del(struct netdev *netdev, const ovs_u128 *ufid,
                                  struct dpif_flow_stats *stats);
+int netdev_dpdk_flow_stats_get(struct netdev *netdev, const ovs_u128 *ufid,
+                               struct dpif_flow_stats *stats);
 
 /*
  * Called by dpif netdev when a port is added/deleted
@@ -63,6 +65,9 @@ void netdev_rte_offload_preprocess(struct dp_packet *packet, uint32_t mark);
 
 #define DPDK_FLOW_OFFLOAD_API                   \
     .flow_put = netdev_rte_offloads_flow_put,   \
-    .flow_del = netdev_rte_offloads_flow_del
+    .flow_del = netdev_rte_offloads_flow_del,   \
+    .flow_stats_get = netdev_dpdk_flow_stats_get
+
+#define DPDK_ETH_PORT_ID_INVALID    RTE_MAX_ETHPORTS
 
 #endif /* netdev-rte-offloads.h */

--- a/lib/netdev.c
+++ b/lib/netdev.c
@@ -2231,6 +2231,17 @@ netdev_flow_del(struct netdev *netdev, const ovs_u128 *ufid,
 }
 
 int
+netdev_flow_stats_get(struct netdev *netdev, const ovs_u128 *ufid,
+                      struct dpif_flow_stats *stats)
+{
+    const struct netdev_class *class = netdev->netdev_class;
+
+    return (class->flow_stats_get
+            ? class->flow_stats_get(netdev, ufid, stats)
+            : EOPNOTSUPP);
+}
+
+int
 netdev_init_flow_api(struct netdev *netdev)
 {
     const struct netdev_class *class = netdev->netdev_class;

--- a/lib/netdev.h
+++ b/lib/netdev.h
@@ -227,6 +227,8 @@ int netdev_flow_get(struct netdev *, struct match *, struct nlattr **actions,
                     struct dpif_flow_attrs *, struct ofpbuf *wbuffer);
 int netdev_flow_del(struct netdev *, const ovs_u128 *,
                     struct dpif_flow_stats *);
+int netdev_flow_stats_get(struct netdev *, const ovs_u128 *,
+                          struct dpif_flow_stats *);
 int netdev_init_flow_api(struct netdev *);
 uint32_t netdev_get_block_id(struct netdev *);
 int netdev_get_hw_info(struct netdev *, int);

--- a/ofproto/ofproto-dpif.c
+++ b/ofproto/ofproto-dpif.c
@@ -5775,6 +5775,9 @@ ofproto_unixctl_dpif_dump_flows(struct unixctl_conn *conn,
         dpif_flow_stats_format(&f.stats, &ds);
         ds_put_cstr(&ds, ", actions:");
         format_odp_actions(&ds, f.actions, f.actions_len, portno_names);
+        if (f.attrs.offloaded) {
+            ds_put_cstr(&ds, ", offloaded:yes");
+        }
         ds_put_char(&ds, '\n');
     }
     dpif_flow_dump_thread_destroy(flow_dump_thread);


### PR DESCRIPTION
This PR consists of cherry-picked patches from Baidu VXLAN release to enable statistics and offload debug information.
It is built on top of branch hwol_for_baidu
It was not tested yet (24-Jun-19)