### PR TITLE
netdev-rte-offloads: Fix set ct_zone action

### DIFF
--- a/lib/netdev-rte-offloads.c
+++ b/lib/netdev-rte-offloads.c
@@ -3965,10 +3965,10 @@ netdev_dpdk_offload_ct_actions(struct flow_data *fdata,
     int ret = 0;
 
     if (cls_info->actions.zone) {
-        netdev_dpdk_add_action_set_reg(&fdata->actions, flow_actions,
-                                       TAG_FIELD_CT_ZONE,
-                                       cls_info->actions.zone);
-        return -1;
+        if (netdev_dpdk_add_action_set_reg(&fdata->actions, flow_actions,
+                                           TAG_FIELD_CT_ZONE,
+                                           cls_info->actions.zone))
+            return -1;
     }
 
     netdev_rte_add_mark_flow_action(&fdata->actions.mark, flow_mark, flow_actions);


### PR DESCRIPTION
Fixes: 85179fc19b8d ("netdev-rte-offloads: Add support for ct-zone action and match")
Signed-off-by: Eli Britstein <elibr@mellanox.com>