### PR TITLE
netdev-rte-offloads: Pass empty string to rte_eal_hotplug_add not NULL

### DIFF
--- a/lib/netdev-rte-offloads.c
+++ b/lib/netdev-rte-offloads.c
@@ -2701,7 +2701,7 @@ netdev_rte_offloads_add_relay(const char *pci,
     }
 
     /* create vf:*/
-    ret = rte_eal_hotplug_add("pci", pci, NULL);
+    ret = rte_eal_hotplug_add("pci", pci, "");
     if (ret) {
         VLOG_ERR("rte_eal_hotplug_add pci failed\n");
         goto err_vf;


### PR DESCRIPTION
DPDK 19.08 explicitly checks drvargs for NULL in call to rte_eal_hotplug_add
and returns EINVAL. Passing an empty string when no arguments are needed solves
the issue.