### PR TITLE
netdev-dpdk: Enable scatter offload regardless of MTU value

### DIFF
--- a/lib/netdev-dpdk.c
+++ b/lib/netdev-dpdk.c
@@ -919,13 +919,11 @@ dpdk_eth_dev_port_config(struct netdev_dpdk *dev, int n_rxq, int n_txq)
     rte_eth_dev_info_get(dev->port_id, &info);
 
     /* As of DPDK 17.11.1 a few PMDs require to explicitly enable
-     * scatter to support jumbo RX.
+     * scatter to support jumbo RX or MTUs below 1k.
      * Setting scatter for the device is done after checking for
      * scatter support in the device capabilites. */
-    if (dev->mtu > RTE_ETHER_MTU) {
-        if (dev->hw_ol_features & NETDEV_RX_HW_SCATTER) {
-            conf.rxmode.offloads |= DEV_RX_OFFLOAD_SCATTER;
-        }
+    if (dev->hw_ol_features & NETDEV_RX_HW_SCATTER) {
+        conf.rxmode.offloads |= DEV_RX_OFFLOAD_SCATTER;
     }
 
     conf.intr_conf.lsc = dev->lsc_interrupt_mode;


### PR DESCRIPTION
Initially scatter was enabled only to support MTUs larger than the
standard Ethernet MTU of 1500. In order to support small MTUs (< 1000)
scatter is also required as the mbuf size is too small to fit the whole
frame.

------- 

When MTU on PF is set to a value lower than 999, OVS allocates 1152 bytes of mbuf, which is not enough to fit a 1500 bytes frame. Startup fails with the following log messages:
```
ovs|00047|dpdk|ERR|net_mlx5: port 0 Rx queue 0: Scatter offload is not configured and no enough mbuf space(1152) to contain the maximum RX packet length(1518) with head-room(128)
ovs|00048|dpdk|ERR|net_mlx5: port 0 unable to allocate queue index 0
ovs|00050|netdev_dpdk|ERR|Interface pf(rxq:1 txq:2 lsc interrupt mode:false) configure error: Cannot allocate memory
ovs|00051|dpif_netdev|ERR|Failed to set interface pf new configuration
```

The obvious fix is to enable RX scatter offload (which appears to be off by default for mlx5 pmd) for any MTU size (before it was enabled for jumbo frames only).

Please advise if this is a sane thing to do.

*Note*: MTUs below 1000 are an option only for IPv4, IPv6 allows minimum MTUs of 1280 bytes, so the issue would not reproduce.