### PR TITLE
netdev-dpdk: Protect rte_flow_query call with mutex

### DIFF
--- a/lib/netdev-dpdk.c
+++ b/lib/netdev-dpdk.c
@@ -4856,6 +4856,22 @@ netdev_dpdk_rte_flow_create(struct netdev *netdev,
     return flow;
 }
 
+int
+netdev_dpdk_rte_flow_query(struct netdev *netdev,
+                           struct rte_flow *flow,
+                           const struct rte_flow_action *action,
+                           void *data,
+                           struct rte_flow_error *error)
+{
+    int ret;
+    struct netdev_dpdk *dev = netdev_dpdk_cast(netdev);
+
+    ovs_mutex_lock(&dev->mutex);
+    ret = ovs_rte_flow_query(dev->port_id, flow, action, data, error);
+    ovs_mutex_unlock(&dev->mutex);
+    return ret;
+}
+
 struct rte_mempool *
 netdev_dpdk_hw_forwarder_get_mempool(const char *name)
 {

--- a/lib/netdev-dpdk.h
+++ b/lib/netdev-dpdk.h
@@ -56,7 +56,12 @@ netdev_dpdk_rte_flow_create(struct netdev *netdev,
                             const struct rte_flow_item *items,
                             const struct rte_flow_action *actions,
                             struct rte_flow_error *error);
-
+int
+netdev_dpdk_rte_flow_query(struct netdev *netdev,
+                           struct rte_flow *flow,
+                           const struct rte_flow_action *action,
+                           void *data,
+                           struct rte_flow_error *error);
 int netdev_dpdk_get_port_id(const struct netdev *netdev);
 bool netdev_dpdk_is_uplink_port(const struct netdev *netdev);
 

--- a/lib/netdev-rte-offloads.c
+++ b/lib/netdev-rte-offloads.c
@@ -36,13 +36,6 @@
 #include "uuid.h"
 #include "unixctl.h"
 
-extern int
-(*ovs_rte_flow_query)(uint16_t port_id,
-                      struct rte_flow *flow,
-                      const struct rte_flow_action *action,
-                      void *data,
-                      struct rte_flow_error *error);
-
 struct flow_data;
 
 #define VXLAN_EXCEPTION_MARK (MIN_RESERVED_MARK + 0)
@@ -1325,8 +1318,8 @@ netdev_rte_offloads_flow_stats_get(struct netdev *netdev OVS_UNUSED,
                 memset(&query, 0, sizeof query);
                 /* reset counters after query */
                 query.reset = 1;
-                ret = ovs_rte_flow_query(dpdk_port_id, rte_flow,
-                                         actions.actions, &query, &error);
+                ret = netdev_dpdk_rte_flow_query(
+                    netd, rte_flow, actions.actions, &query, &error);
                 if (ret) {
                     /* TODO: moved to once as this fails due to current WA */
                     VLOG_DBG_ONCE("ufid "UUID_FMT


### PR DESCRIPTION
All dpdk APIs (e.g rte_flow_create, rte_flow_destroy) must be mutex
protected. This commit protects rte_flow_query API.

Signed-off-by: Ophir Munk <ophirmu@mellanox.com>